### PR TITLE
Edit/about page

### DIFF
--- a/app/components/about/about-bar-area.tsx
+++ b/app/components/about/about-bar-area.tsx
@@ -37,7 +37,7 @@ const AboutBarArea: React.FC<TProps> = ({ title, aboutPageData }) => {
         >
           {aboutPageData.map((value: aboutDataProps) => (
             <Box pb={{ xs: 6, md: 10 }} key={value.subTitle}>
-              <Typography component="h3" fontSize={{ xs: 18, sm: 20 }}>
+              <Typography component="h3" fontSize={{ xs: 18, sm: 20 }} fontWeight={"bold"}>
                 {value.subTitle}
               </Typography>
               <Typography

--- a/app/components/about/about-message-area.tsx
+++ b/app/components/about/about-message-area.tsx
@@ -21,6 +21,7 @@ const AboutMessageArea: React.FC<TProps> = ({ title, comment }) => {
         justifyContent={"center"}
         alignItems={"center"}
         border={"1px solid #E6E6E6"}
+        borderRadius={"8px"}
         p={{ xs: 2, md: 9 }}
       >
         <Box display={"flex"} alignItems={"center"} mr={{ md: 4 }}>


### PR DESCRIPTION
## やったこと
- Aboutページのタイトルを太文字に変更
- 代表からのメッセージのborderRadiusを8pxに変更

## 挙動
<img width="1435" alt="スクリーンショット 2024-11-01 15 07 11" src="https://github.com/user-attachments/assets/c82d205b-b8b1-49ec-93c3-371aafbc3db4">
<img width="1440" alt="スクリーンショット 2024-11-01 15 07 26" src="https://github.com/user-attachments/assets/c4d42ccf-56ec-4f2a-a5da-71baf2654a56">
