### PR TITLE
Fix/firstview

### DIFF
--- a/app/components/home/introduction/first-view.tsx
+++ b/app/components/home/introduction/first-view.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Box } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Autoplay, Pagination, Grid } from "swiper/modules";
 import "swiper/css";
@@ -21,23 +21,22 @@ const FirstView = () => {
 
   return (
     <Box
-      position={{ md: "relative" }}
       display={"flex"}
+      position={"relative"}
       alignItems={"center"}
-      flexDirection={{ xs: "column", md: "row" }}
-      height={{ xs: "70vh", md: "100vh" }}
-      mt={{ md: 5 }}
+      justifyContent={"center"}
+      height={{ xs: "38vh", md: "82vh" }}
+      width={"100%"}
     >
-      <Box position={{ md: "absolute" }} top={{ md: 70 }} zIndex={200}>
-        <ThreejsText />
-      </Box>
       <Box
-        position={{ md: "absolute" }}
-        top={{ md: 60 }}
-        right={{ md: 40 }}
-        width={{ xs: "100%", md: "55%" }}
-        height={{ xs: "24vh", md: "65vh" }}
-        ml={{ md: 5 }}
+        position={"absolute"}
+        top={0}
+        left={0}
+        width={{ xs: "100%", md: "100%" }}
+        //ここを100にすると画面いっぱい。70にすると画面下の余白ができる
+        // height={{ xs: "100%", md: "100vh" }}
+        height={{ xs: "30vh", md: "70vh" }}
+        bgcolor="rgba(0, 0, 0, 1)" // 半透明な黒
       >
         <Swiper
           loop={true}
@@ -55,11 +54,11 @@ const FirstView = () => {
           breakpoints={{
             320: {
               slidesPerView: 1.2,
-              spaceBetween: 20,
+              spaceBetween: 0,
             },
             640: {
-              slidesPerView: 1,
-              spaceBetween: 40,
+              slidesPerView: 1.5,
+              spaceBetween: 0,
             },
           }}
           modules={[Grid, Pagination, Autoplay]}
@@ -78,12 +77,53 @@ const FirstView = () => {
                 alt={"image"}
                 style={{
                   objectFit: "cover",
-                  borderRadius: 15,
+                  zIndex: -1,
+                  opacity: 0.5,
                 }}
               />
             </SwiperSlide>
           ))}
         </Swiper>
+        <Box
+          position="absolute"
+          top="50%"
+          left="50%"
+          textAlign="center"
+          zIndex={2}
+          color="white"
+          sx={{ transform: "translate(-50%, -50%)" }}
+        >
+          <Typography
+            variant="h2"
+            fontFamily="-apple-system"
+            letterSpacing={3}
+            mt="5rem"
+            mb="1rem"
+            sx={{
+              color: "white",
+              fontSize: { xs: "2rem", md: 38 },
+              fontWeight: "bold",
+            }}
+          >
+            PeachTech
+          </Typography>
+
+          <Typography
+            variant="subtitle1"
+            fontFamily="Arial"
+            letterSpacing={4}
+            sx={{
+              color: "white",
+              fontSize: { xs: "1rem", md: 26 },
+              mt: 2, // 上に少し間隔を空ける
+            }}
+          >
+            〜明日を創造する第一歩をともに〜
+          </Typography>
+          {/* <Box sx={{ mt: 1 }}>
+            <ThreejsText />
+          </Box> */}
+        </Box>
       </Box>
     </Box>
   );

--- a/app/components/home/introduction/first-view.tsx
+++ b/app/components/home/introduction/first-view.tsx
@@ -25,18 +25,11 @@ const FirstView = () => {
       position={"relative"}
       alignItems={"center"}
       justifyContent={"center"}
-      height={{ xs: "38vh", md: "82vh" }}
-      width={"100%"}
     >
       <Box
-        position={"absolute"}
-        top={0}
-        left={0}
-        width={{ xs: "100%", md: "100%" }}
-        //ここを100にすると画面いっぱい。70にすると画面下の余白ができる
-        // height={{ xs: "100%", md: "100vh" }}
         height={{ xs: "30vh", md: "70vh" }}
-        bgcolor="rgba(0, 0, 0, 1)" // 半透明な黒
+        width={"100%"}
+        bgcolor={"rgba(0, 0, 0, 1)"} // 半透明な黒
       >
         <Swiper
           loop={true}
@@ -77,7 +70,6 @@ const FirstView = () => {
                 alt={"image"}
                 style={{
                   objectFit: "cover",
-                  zIndex: -1,
                   opacity: 0.5,
                 }}
               />
@@ -85,38 +77,32 @@ const FirstView = () => {
           ))}
         </Swiper>
         <Box
-          position="absolute"
-          top="50%"
-          left="50%"
-          textAlign="center"
-          zIndex={2}
-          color="white"
+          position={"absolute"}
+          top={"37%"}
+          left={"50%"}
+          zIndex={1}
+          color={"white"}
           sx={{ transform: "translate(-50%, -50%)" }}
         >
           <Typography
-            variant="h2"
-            fontFamily="-apple-system"
+            fontFamily={"-apple-system"}
+            textAlign={"center"}
             letterSpacing={3}
-            mt="5rem"
-            mb="1rem"
-            sx={{
-              color: "white",
-              fontSize: { xs: "2rem", md: 38 },
-              fontWeight: "bold",
-            }}
+            mt={5}
+            mb={1}
+            color={"white"}
+            fontSize={{ xs: 19, md: 38 }}
+            fontWeight={"bold"}
           >
             PeachTech
           </Typography>
-
           <Typography
-            variant="subtitle1"
-            fontFamily="Arial"
+            fontFamily={"Arial"}
             letterSpacing={4}
-            sx={{
-              color: "white",
-              fontSize: { xs: "1rem", md: 26 },
-              mt: 2, // 上に少し間隔を空ける
-            }}
+            color={"white"}
+            fontSize={{ xs: 13, md: 20 }}
+            mt={2} // 上に少し間隔を空ける
+            whiteSpace={"nowrap"}
           >
             〜明日を創造する第一歩をともに〜
           </Typography>

--- a/app/components/home/introduction/first-view.tsx
+++ b/app/components/home/introduction/first-view.tsx
@@ -78,7 +78,7 @@ const FirstView = () => {
         </Swiper>
         <Box
           position={"absolute"}
-          top={"37%"}
+          top={"45%"}
           left={"50%"}
           zIndex={1}
           color={"white"}

--- a/app/components/home/introduction/threejs-text.tsx
+++ b/app/components/home/introduction/threejs-text.tsx
@@ -8,7 +8,7 @@ import { Box, useMediaQuery, useTheme } from "@mui/material";
 const ThreejsText = () => {
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
-  
+
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const sceneRef = useRef<THREE.Scene | null>(null);
@@ -22,14 +22,18 @@ const ThreejsText = () => {
       const newPosition = isSmallScreen
         ? { x: 0, y: -100, z: 720 }
         : { x: -120, y: -100, z: 720 };
-      
-      cameraRef.current.position.set(newPosition.x, newPosition.y, newPosition.z);
+
+      cameraRef.current.position.set(
+        newPosition.x,
+        newPosition.y,
+        newPosition.z
+      );
       cameraRef.current.updateProjectionMatrix();
-      
+
       if (controlsRef.current) {
         controlsRef.current.update();
       }
-      
+
       // シーンを再レンダリング
       if (sceneRef.current) {
         rendererRef.current.render(sceneRef.current, cameraRef.current);
@@ -73,12 +77,16 @@ const ThreejsText = () => {
       10000
     );
     cameraRef.current = camera;
-    
+
     // 初期カメラ位置の設定
     const initialPosition = isSmallScreen
-      ? { x: 0, y: -100, z: 720 }
-      : { x: -120, y: -100, z: 720 };
-    camera.position.set(initialPosition.x, initialPosition.y, initialPosition.z);
+      ? { x: 0, y: -100, z: 520 }
+      : { x: 0, y: -100, z: 520 };
+    camera.position.set(
+      initialPosition.x,
+      initialPosition.y,
+      initialPosition.z
+    );
 
     // レンダリング関数
     const render = () => {
@@ -88,7 +96,7 @@ const ThreejsText = () => {
     // フォントローダー
     const loader = new FontLoader();
     loader.load("/fonts/Shippori Mincho B1_Bold.json", function (font) {
-      const color = 0x006699;
+      const color = 0xffffff;
 
       const matDark = new THREE.LineBasicMaterial({
         color: color,
@@ -98,7 +106,7 @@ const ThreejsText = () => {
       const matLite = new THREE.MeshBasicMaterial({
         color: color,
         transparent: true,
-        opacity: 0.4,
+        opacity: 0.8,
         side: THREE.DoubleSide,
       });
 
@@ -166,6 +174,14 @@ const ThreejsText = () => {
     controls.target.set(0, 0, 0);
     controls.update();
 
+    // カメラの回転制限を設定
+    controls.maxPolarAngle = Math.PI / 1.8; // 回転範囲を制限
+    controls.minPolarAngle = Math.PI / 2;
+
+    // 横の回転範囲を設定（必要に応じて調整）
+    controls.minAzimuthAngle = -Math.PI / 4; // 左方向の最大角度
+    controls.maxAzimuthAngle = Math.PI / 4; // 右方向の最大角度
+
     controls.addEventListener("change", render);
 
     window.addEventListener("resize", handleResize);
@@ -181,16 +197,20 @@ const ThreejsText = () => {
   return (
     <Box
       ref={containerRef}
-      width={{ xs: "100vw", md: "45vw" }}
-      height={{ xs: "35vh", md: "65vh" }}
+      width={{ xs: "100vw", md: "60vw" }}
+      height={{ xs: "15vh", md: "30vh" }}
       position={"relative"}
+      mb={{ xs: 2, md: 5 }}
+      sx={{
+        color: "white",
+        fontSize: { xs: "1rem", md: 26 },
+      }}
     >
       <canvas
         ref={canvasRef}
         style={{
-          position: "absolute",
-          width: "100%",
-          height: "100%",
+          width: "150%",
+          height: "150%",
         }}
       />
     </Box>


### PR DESCRIPTION
@yusei53 
## やったこと
- 写真を暗くオーバーラップ、画面全体に表示、横に流れるようにした。
- three.jsを中心に表示、文字の可働範囲を制御。

## やりたいこと
- three.jsか文字列かを選ぶ
- レスポンシブの時にthree.jsを表示させるか

## やってないこと
- レスポンシブ対応

## UI(文字バージョン)
<img width="1470" alt="スクリーンショット 2024-11-16 17 46 58" src="https://github.com/user-attachments/assets/797c9b3c-f47d-4e13-ac29-193aa1ee67d8">

（three.js version）
<img width="1470" alt="スクリーンショット 2024-11-16 17 10 59" src="https://github.com/user-attachments/assets/dbf066d7-0da4-4895-9dc9-8c9c5d9a0bdd">

